### PR TITLE
Ensure pdfs are reset and subtypes updated.

### DIFF
--- a/src/edo/population.py
+++ b/src/edo/population.py
@@ -65,9 +65,9 @@ def create_new_population(
     population = parents
     while len(population) < size:
         parent1_idx, parent2_idx = np.random.choice(len(parents), size=2)
-        parent1, parent2 = parents[parent1_idx], parents[parent2_idx]
+        parents_ = parents[parent1_idx], parents[parent2_idx]
         offspring = crossover(
-            parent1, parent2, col_limits, pdfs, crossover_prob
+            *parents_, col_limits, pdfs, crossover_prob
         )
         mutant = mutation(
             offspring, mutation_prob, row_limits, col_limits, pdfs, weights

--- a/src/edo/run.py
+++ b/src/edo/run.py
@@ -1,5 +1,7 @@
 """ .. The main script containing a generic genetic algorithm. """
 
+from collections import defaultdict
+
 import numpy as np
 
 from .fitness import get_fitness
@@ -93,8 +95,8 @@ def run_algorithm(
         The seed for a particular run of the genetic algorithm. If :code:`None`,
         no seed is set.
     fitness_kwargs : dict
-        Any additional parameters that need to be passed to :code:`fitness` should
-        be placed here as a dictionary or suitable mapping.
+        Any additional parameters that need to be passed to :code:`fitness`
+        should be placed here as a dictionary or suitable mapping.
 
     Returns
     -------
@@ -110,6 +112,9 @@ def run_algorithm(
 
     if seed is not None:
         np.random.seed(seed)
+
+    for pdf in pdfs:
+        pdf.reset()
 
     population = create_initial_population(
         size, row_limits, col_limits, pdfs, weights
@@ -129,6 +134,7 @@ def run_algorithm(
         parents = selection(
             population, pop_fitness, best_prop, lucky_prop, maximise
         )
+        pdfs = _update_subtypes(parents, pdfs)
 
         population = create_new_population(
             parents,
@@ -154,3 +160,18 @@ def run_algorithm(
             pdfs = shrink(parents, pdfs, itr, shrinkage)
 
     return population, pop_fitness, all_populations, all_fitnesses
+
+
+def _update_subtypes(parents, pdfs):
+    """ Update the recorded subtypes for each pdf to be only those present in
+    the parents. """
+
+    subtypes = defaultdict(set)
+    for parent in parents:
+        for column in parent.metadata:
+            subtypes[column.parent].add(column.__class__)
+
+    for pdf in pdfs:
+        pdf.subtypes = list(subtypes[pdf])
+
+    return pdfs


### PR DESCRIPTION
Resetting:
  - Previously, running an example twice gave different results
  - This was because each pdf passed to the algorithm would develop
  subtypes in the first run.
  - Now, each pdf family is reset at the start of the run so they have no
  subtypes. I'm hoping garbage collection catches this.

Updating subtypes:
  - The available subtypes from which to generate columns is now updated
  for each pdf from those present in a generation's parents.