### PR TITLE
Implement a maximum number of subtypes.

### DIFF
--- a/src/edo/pdfs/base.py
+++ b/src/edo/pdfs/base.py
@@ -21,6 +21,7 @@ class Distribution:
 
     name = "Distribution"
     subtypes = []
+    max_subtypes = None
     param_limits = None
 
     def __repr__(self):
@@ -58,10 +59,14 @@ class Distribution:
 
     @classmethod
     def make_instance(cls):
-        """ Choose an existing subtype or build a new one. Return an instance of
-        that subtype. """
+        """ Choose an existing subtype or build a new one if there is space
+        available in their subtype list. Return an instance of that subtype. """
 
-        subtype = np.random.choice(cls.subtypes + [cls.build_subtype])
+        choices = list(cls.subtypes)
+        if cls.max_subtypes is None or len(choices) < cls.max_subtypes:
+            choices.append(cls.build_subtype)
+
+        subtype = np.random.choice(choices)
         if subtype == cls.build_subtype:
             subtype = cls.build_subtype()
 
@@ -69,9 +74,7 @@ class Distribution:
 
     @classmethod
     def reset(cls):
-        """ Reset the class to have its original parameter limits, i.e. those
-        given in the class attribute :code:`param_limits` when the first
-        instance is made. """
+        """ Reset the class to have no subtypes. """
 
         cls.subtypes = []
 

--- a/tests/pdfs/test_common.py
+++ b/tests/pdfs/test_common.py
@@ -83,6 +83,24 @@ def test_make_instance(family):
 
 
 @given(family=sampled_from(all_pdfs))
+def test_max_subtypes(family):
+    """ Test that distribution objects cannot make more subtypes than their
+    prescribed maximum. """
+
+    family.reset()
+
+    family.max_subtypes = 0
+    with pytest.raises(ValueError):
+        family.make_instance()
+
+    family.max_subtypes = 1
+    family.make_instance()
+    subtype = family.subtypes[0]
+    pdf = family.make_instance()
+    assert isinstance(pdf, subtype)
+
+
+@given(family=sampled_from(all_pdfs))
 def test_reset(family):
     """ Test that distribution classes can be reset. """
 
@@ -91,9 +109,7 @@ def test_reset(family):
     assert family.subtypes == []
 
 
-@given(
-    family=sampled_from(all_pdfs), nrows=integers(min_value=0, max_value=1000)
-)
+@given(family=sampled_from(all_pdfs), nrows=integers(min_value=0, max_value=99))
 def test_sample(family, nrows):
     """ Verify that distribution objects can sample correctly. """
 


### PR DESCRIPTION
Following discussions with @drvinceknight about how we want subtypes to behave, a maximum number can now be specified for each distribution class.