### PR TITLE
Add `Loader` param to `yaml.load` calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *_build*
 .cache/
 *coverage*
+dask-worker-space
 dist
 *egg-info*
 htmlcov/

--- a/src/edo/run.py
+++ b/src/edo/run.py
@@ -293,7 +293,7 @@ def _get_pop_history(root, itr):
             ind_dir = Path(ind_dir)
             dataframe = dd.read_csv(ind_dir / "main.csv")
             with open(ind_dir / "main.meta", "r") as meta_file:
-                metadata = yaml.load(meta_file)
+                metadata = yaml.load(meta_file, Loader=yaml.Loader)
 
             generation.append(Individual(dataframe, metadata))
 

--- a/src/edo/run.py
+++ b/src/edo/run.py
@@ -293,7 +293,7 @@ def _get_pop_history(root, itr):
             ind_dir = Path(ind_dir)
             dataframe = dd.read_csv(ind_dir / "main.csv")
             with open(ind_dir / "main.meta", "r") as meta_file:
-                metadata = yaml.load(meta_file, Loader=yaml.Loader)
+                metadata = yaml.load(meta_file, Loader=yaml.FullLoader)
 
             generation.append(Individual(dataframe, metadata))
 

--- a/tests/unit/test_write.py
+++ b/tests/unit/test_write.py
@@ -32,7 +32,7 @@ def test_write_individual(row_limits, col_limits, weights):
 
     df = pd.read_csv(path / "main.csv")
     with open(path / "main.meta", "r") as meta_file:
-        meta = yaml.load(meta_file, Loader=yaml.Loader)
+        meta = yaml.load(meta_file, Loader=yaml.FullLoader)
 
     assert np.allclose(df.values, individual.dataframe.values)
     assert meta == [m.to_dict() for m in individual.metadata]
@@ -90,7 +90,7 @@ def test_write_generation_serial(size, row_limits, col_limits, weights):
 
         df = pd.read_csv(ind_path / "main.csv")
         with open(ind_path / "main.meta", "r") as meta_file:
-            meta = yaml.load(meta_file, Loader=yaml.Loader)
+            meta = yaml.load(meta_file, Loader=yaml.FullLoader)
 
         assert np.allclose(df.values, ind.dataframe.values)
         assert meta == [m.to_dict() for m in ind.metadata]
@@ -129,7 +129,7 @@ def test_write_generation_parallel(size, row_limits, col_limits, weights):
 
         df = pd.read_csv(ind_path / "main.csv")
         with open(ind_path / "main.meta", "r") as meta_file:
-            meta = yaml.load(meta_file, Loader=yaml.Loader)
+            meta = yaml.load(meta_file, Loader=yaml.FullLoader)
 
         assert np.allclose(df.values, ind.dataframe.values)
         assert meta == [m.to_dict() for m in ind.metadata]

--- a/tests/unit/test_write.py
+++ b/tests/unit/test_write.py
@@ -32,7 +32,7 @@ def test_write_individual(row_limits, col_limits, weights):
 
     df = pd.read_csv(path / "main.csv")
     with open(path / "main.meta", "r") as meta_file:
-        meta = yaml.load(meta_file)
+        meta = yaml.load(meta_file, Loader=yaml.Loader)
 
     assert np.allclose(df.values, individual.dataframe.values)
     assert meta == [m.to_dict() for m in individual.metadata]
@@ -90,7 +90,7 @@ def test_write_generation_serial(size, row_limits, col_limits, weights):
 
         df = pd.read_csv(ind_path / "main.csv")
         with open(ind_path / "main.meta", "r") as meta_file:
-            meta = yaml.load(meta_file)
+            meta = yaml.load(meta_file, Loader=yaml.Loader)
 
         assert np.allclose(df.values, ind.dataframe.values)
         assert meta == [m.to_dict() for m in ind.metadata]
@@ -129,7 +129,7 @@ def test_write_generation_parallel(size, row_limits, col_limits, weights):
 
         df = pd.read_csv(ind_path / "main.csv")
         with open(ind_path / "main.meta", "r") as meta_file:
-            meta = yaml.load(meta_file)
+            meta = yaml.load(meta_file, Loader=yaml.Loader)
 
         assert np.allclose(df.values, ind.dataframe.values)
         assert meta == [m.to_dict() for m in ind.metadata]


### PR DESCRIPTION
Removes the warning raised due to the following deprecation in PyYAML: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation