### PR TITLE
Saving histories (individuals and their metadata)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pip=20.1.1
   - pytest=5.4.3
   - pytest-cov=2.10.0
+  - scipy>=1.5
   - pip:
     - black==19.10b0
     - flake8==3.8.3

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,19 @@
+name: edo-dev
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - python=3.7.7
+  - dask=2.21
+  - ipykernel
+  - matplotlib>=3.2
+  - numpy=1.18
+  - pandas=1.0.5
+  - pip=20.1.1
+  - pytest=5.4.3
+  - pytest-cov=2.10.0
+  - pip:
+    - black==19.10b0
+    - flake8==3.8.3
+    - hypothesis==5.20.3
+    - isort==5.1.4

--- a/src/edo/distributions/base.py
+++ b/src/edo/distributions/base.py
@@ -10,12 +10,3 @@ class Distribution(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def sample(self, nrows=None):
         """ A placeholder function for sampling from the distribution. """
-
-    def to_dict(self):
-        """ Returns a dictionary containing the name of distribution, and the
-        values of all its parameters. """
-
-        out = dict(vars(self))
-        out["name"] = self.name
-
-        return out

--- a/src/edo/family.py
+++ b/src/edo/family.py
@@ -1,6 +1,5 @@
 """ The distribution-subtype handler and its supporting functions. """
 
-import json
 import os
 import pathlib
 import pickle

--- a/src/edo/family.py
+++ b/src/edo/family.py
@@ -1,5 +1,6 @@
 """ The distribution-subtype handler and its supporting functions. """
 
+import json
 import os
 import pathlib
 import pickle
@@ -57,6 +58,7 @@ class Family:
         subtype = type(subtype_name, (self.distribution,), attributes)
         subtype.subtype_id = self.subtype_id
         subtype.family = self
+        subtype.to_dict = _subtype_to_dict
 
         self.subtypes[self.subtype_id] = subtype
         self.all_subtypes[self.subtype_id] = subtype
@@ -131,5 +133,20 @@ def _get_attrs_for_subtype(obj):
         "__init__": obj.__init__,
         "__repr__": obj.__repr__,
     }
+
+    return attributes
+
+
+def _subtype_to_dict(self):
+    """ Convert an unpickleable subtype instance to a dictionary so it can be
+    recovered at a later date. """
+
+    attributes = {"name": self.name, "subtype_id": self.subtype_id}
+
+    params = {}
+    for param, val in vars(self).items():
+        params[param] = val
+
+    attributes["params"] = params
 
     return attributes

--- a/src/edo/fitness.py
+++ b/src/edo/fitness.py
@@ -39,7 +39,6 @@ def get_population_fitness(population, fitness, processes=None, **kwargs):
     return list(out)
 
 
-@dask.delayed
 def write_fitness(fitness, generation, root):
     """ Write the generation fitness to file in the root directory. """
 

--- a/src/edo/individual.py
+++ b/src/edo/individual.py
@@ -1,14 +1,13 @@
-""" A collection of objects related to the definition and creation of an
-individual in this EA. An individual is defined by a dataframe and its
-associated metadata. This metadata is simply a list of the distributions from
-which each column of the dataframe was generated. These are reused during
-mutation and for filling in missing values during crossover. """
+""" A collection of objects to facilitate an individual representation. """
 
+import json
+import pickle
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import yaml
+
+from .family import Family
 
 
 class Individual:
@@ -40,21 +39,34 @@ class Individual:
             yield val
 
     @classmethod
-    def from_file(cls, path):
+    def from_file(cls, distributions, generation, index, root):
         """ Create an instance of `Individual` from files at `path`. """
 
+        path = Path(root) / str(generation) / str(index)
+        distributions = {dist.name: dist for dist in distributions}
+
         dataframe = pd.read_csv(path / "main.csv")
-        with open(path / "main.meta", "r") as meta_file:
-            metadata = yaml.load(meta_file, Loader=yaml.FullLoader)
+
+        with open(path / "main.meta", "r") as meta:
+            meta_dicts = json.load(meta)
+
+        root = path.parts[-3]
+        metadata = []
+        for meta in meta_dicts:
+            distribution = meta["name"]
+            family = globals().get(f"{distribution}Family", None)
+            if family is None:
+                distribution = distributions[distribution]
+                family = Family.load(distribution, root)
+
+            subtype_id = meta["subtype_id"]
+            subtype = family.subtypes[subtype_id]
+
+            pdf = subtype.__new__(subtype)
+            pdf.__dict__.update(meta["params"])
+            metadata.append(pdf)
 
         return Individual(dataframe, metadata)
-
-    def to_history(self):
-        """ Export a copy of itself fit for a population history, i.e. with
-        dictionary metadata as sampling is no longer required. """
-
-        meta_dicts = [pdf.to_dict() for pdf in self.metadata]
-        return Individual(self.dataframe, meta_dicts)
 
     def to_file(self, generation, index, root):
         """ Write self to file. """
@@ -62,10 +74,15 @@ class Individual:
         path = Path(root) / str(generation) / str(index)
         path.mkdir(exist_ok=True, parents=True)
 
-        dataframe, metadata = self.to_history()
-        dataframe.to_csv(path / "main.csv", index=False)
-        with open(path / "main.meta", "w") as meta_file:
-            yaml.dump(metadata, meta_file)
+        self.dataframe.to_csv(path / "main.csv", index=False)
+
+        meta_dicts = []
+        for pdf in self.metadata:
+            pdf.family.save(root)
+            meta_dicts.append(pdf.to_dict())
+
+        with open(path / "main.meta", "w") as meta:
+            json.dump(meta_dicts, meta)
 
         return path
 

--- a/src/edo/individual.py
+++ b/src/edo/individual.py
@@ -117,7 +117,14 @@ def _get_minimum_columns(nrows, col_limits, families, family_counts):
 
 
 def _get_remaining_columns(
-    columns, metadata, nrows, ncols, col_limits, families, weights, family_counts
+    columns,
+    metadata,
+    nrows,
+    ncols,
+    col_limits,
+    families,
+    weights,
+    family_counts,
 ):
     """ Sample all remaining columns for the current individual. If
     :code:`col_limits` has a tuple upper limit then sample all remaining
@@ -173,7 +180,14 @@ def create_individual(row_limits, col_limits, families, weights=None):
         )
 
     cols, metadata = _get_remaining_columns(
-        cols, metadata, nrows, ncols, col_limits, families, weights, family_counts
+        cols,
+        metadata,
+        nrows,
+        ncols,
+        col_limits,
+        families,
+        weights,
+        family_counts,
     )
 
     dataframe = pd.DataFrame({i: col for i, col in enumerate(cols)})

--- a/src/edo/operators/shrink.py
+++ b/src/edo/operators/shrink.py
@@ -69,7 +69,9 @@ def shrink(parents, families, itr, shrinkage):
 
     for family in families:
         for i, subtype in family.subtypes.items():
-            subtype = _adjust_subtype_param_limits(parents, subtype, itr, shrinkage)
+            subtype = _adjust_subtype_param_limits(
+                parents, subtype, itr, shrinkage
+            )
             family.subtypes[i] = subtype
 
     return families

--- a/src/edo/operators/util.py
+++ b/src/edo/operators/util.py
@@ -6,8 +6,6 @@ def get_family_counts(metadata, families):
     `families`. """
 
     return {
-        family: sum(
-            [pdf.family is family for pdf in metadata]
-        )
+        family: sum([pdf.family is family for pdf in metadata])
         for family in families
     }

--- a/src/edo/optimiser.py
+++ b/src/edo/optimiser.py
@@ -111,8 +111,8 @@ class DataOptimiser:
         self.generation = 0
         self.population = None
         self.pop_fitness = None
-        self.pop_history = None
-        self.fit_history = None
+        self.pop_history = []
+        self.fit_history = pd.DataFrame()
 
     def stop(self, **kwargs):
         """ A placeholder for a function which acts as a stopping condition on
@@ -225,14 +225,7 @@ class DataOptimiser:
     def _update_pop_history(self):
         """ Add the current generation to the history. """
 
-        population_with_dicts = []
-        for individual in self.population:
-            population_with_dicts.append(individual.to_history())
-
-        if self.pop_history is None:
-            self.pop_history = [population_with_dicts]
-        else:
-            self.pop_history.append(population_with_dicts)
+        self.pop_history.append(self.population)
 
     def _update_fit_history(self):
         """ Add the current generation's population fitness to the history. """
@@ -245,12 +238,9 @@ class DataOptimiser:
             }
         )
 
-        if self.fit_history is None:
-            self.fit_history = fitness_df
-        else:
-            self.fit_history = self.fit_history.append(
-                fitness_df, ignore_index=True
-            )
+        self.fit_history = self.fit_history.append(
+            fitness_df, ignore_index=True
+        )
 
     def _write_generation(self, root, processes):
         """ Write all individuals in a generation and their collective fitnesses

--- a/src/edo/optimiser.py
+++ b/src/edo/optimiser.py
@@ -1,10 +1,8 @@
 """ .. The main script containing the evolutionary dataset algorithm. """
 
 from collections import defaultdict
-from glob import iglob
 from pathlib import Path
 
-import dask
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd

--- a/src/edo/population.py
+++ b/src/edo/population.py
@@ -7,7 +7,9 @@ from .individual import create_individual
 from .operators import crossover, mutation
 
 
-def create_initial_population(size, row_limits, col_limits, families, weights=None):
+def create_initial_population(
+    size, row_limits, col_limits, families, weights=None
+):
     """ Create an initial population for the genetic algorithm based on the
     given parameters.
 

--- a/tests/distributions/test_common.py
+++ b/tests/distributions/test_common.py
@@ -55,19 +55,6 @@ def test_sample(distribution, nrows):
 
 
 @given(distribution=sampled_from(all_distributions))
-def test_to_dict(distribution):
-    """ Verify that objects can pass their information to a dictionary of the
-    correct form. """
-
-    pdf = distribution()
-    pdf_dict = pdf.to_dict()
-    assert pdf_dict["name"] == pdf.name
-
-    for param in pdf.param_limits:
-        assert pdf_dict[param] == vars(pdf)[param]
-
-
-@given(distribution=sampled_from(all_distributions))
 def test_set_param_limits(distribution):
     """ Check distribution classes can have their default parameter limits
     changed. """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -44,12 +44,14 @@ def run_circle_example():
     fit_histories = []
     for seed in range(3):
 
+        families = [edo.Family(RadiusUniform), edo.Family(AngleUniform)]
+
         do = edo.DataOptimiser(
             fitness=circle_fitness,
             size=10,
             row_limits=[5, 10],
             col_limits=[(1, 1), (1, 1)],
-            distributions=[RadiusUniform, AngleUniform],
+            families=families,
             max_iter=3,
             best_prop=0.1,
             mutation_prob=0.01,

--- a/tests/test_fitness.py
+++ b/tests/test_fitness.py
@@ -28,9 +28,7 @@ def test_get_fitness(row_limits, col_limits, weights):
     distributions = [Normal, Poisson, Uniform]
     families = [edo.Family(dist) for dist in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
     dataframe = individual.dataframe
 
     fit = get_fitness(dataframe, trivial_fitness).compute()
@@ -52,9 +50,7 @@ def test_get_fitness_kwargs(row_limits, col_limits, weights):
     distributions = [Normal, Poisson, Uniform]
     families = [edo.Family(dist) for dist in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
     dataframe = individual.dataframe
 
     fit = get_fitness(dataframe, trivial_fitness, **fitness_kwargs).compute()

--- a/tests/test_fitness.py
+++ b/tests/test_fitness.py
@@ -123,8 +123,8 @@ def test_write_fitness(size):
     fitness = [trivial_fitness(pd.DataFrame()) for _ in range(size)]
     path = Path(".testcache")
 
-    write_fitness(fitness, generation=0, root=path).compute()
-    write_fitness(fitness, generation=1, root=path).compute()
+    write_fitness(fitness, generation=0, root=path)
+    write_fitness(fitness, generation=1, root=path)
     assert (path / "fitness.csv").exists()
 
     fit = pd.read_csv(path / "fitness.csv")

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import yaml
 from hypothesis import given
 from hypothesis.strategies import text
 
@@ -41,9 +40,7 @@ def test_integer_limits(row_limits, col_limits, weights):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
     dataframe, metadata = individual
 
     assert isinstance(individual, Individual)
@@ -69,9 +66,7 @@ def test_integer_tuple_limits(row_limits, col_limits, weights):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
     dataframe, metadata = individual
 
     assert isinstance(individual, Individual)
@@ -101,9 +96,7 @@ def test_tuple_integer_limits(row_limits, col_limits, weights):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
     dataframe, metadata = individual
 
     assert isinstance(individual, Individual)
@@ -133,9 +126,7 @@ def test_tuple_limits(row_limits, col_limits, weights):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
     dataframe, metadata = individual
 
     assert isinstance(individual, Individual)
@@ -165,9 +156,7 @@ def test_to_and_from_file(row_limits, col_limits, weights):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
 
     individual.to_file(path, ".testcache")
     assert (path / "main.csv").exists()

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -157,9 +157,10 @@ def test_tuple_limits(row_limits, col_limits, weights):
 
 
 @INTEGER_INDIVIDUAL
-def test_to_history(row_limits, col_limits, weights):
-    """ Test that an individual can export themselves to a version fit for a
-    population history. """
+def test_to_and_from_file(row_limits, col_limits, weights):
+    """ Test that an individual can be saved to and created from file. """
+
+    root = Path(".testcache")
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -167,60 +168,21 @@ def test_to_history(row_limits, col_limits, weights):
     individual = create_individual(
         row_limits, col_limits, families, weights
     )
-    history_individual = individual.to_history()
 
-    assert isinstance(history_individual, Individual)
-    assert history_individual.dataframe.equals(individual.dataframe)
+    individual.to_file(0, 0, root)
+    assert (root / "0/0/main.csv").exists()
+    assert (root / "0/0/main.meta").exists()
 
-    for i, pdf in enumerate(history_individual.metadata):
-        assert pdf == individual.metadata[i].to_dict()
+    saved_individual = Individual.from_file(distributions, 0, 0, root)
 
-
-@INTEGER_INDIVIDUAL
-def test_from_file(row_limits, col_limits, weights):
-    """ Test that an individual can be created from file. """
-
-    path = Path("out/0/0")
-    path.mkdir(exist_ok=True, parents=True)
-
-    distributions = [Gamma, Normal, Poisson]
-    families = [Family(distribution) for distribution in distributions]
-
-    dataframe, metadata = create_individual(
-        row_limits, col_limits, families, weights
+    assert np.allclose(
+        saved_individual.dataframe.values, individual.dataframe.values
     )
 
-    dataframe.to_csv(path / "main.csv", index=False)
-    with open(path / "main.meta", "w") as meta_file:
-        yaml.dump([m.to_dict() for m in metadata], meta_file)
+    for saved_pdf, pdf in zip(saved_individual.metadata, individual.metadata):
 
-    individual = Individual.from_file(path)
-    assert np.allclose(individual.dataframe.values, dataframe.values)
-    assert individual.metadata == [m.to_dict() for m in metadata]
+        assert saved_pdf.family.name == pdf.family.name
+        assert saved_pdf.family.distribution is pdf.family.distribution
+        assert saved_pdf.to_dict() == pdf.to_dict()
 
-    os.system("rm -r out")
-
-
-@INTEGER_INDIVIDUAL
-def test_to_file(row_limits, col_limits, weights):
-    """ Test that an individual can write themselves to file. """
-
-    distributions = [Gamma, Normal, Poisson]
-    families = [Family(distribution) for distribution in distributions]
-
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
-    path = individual.to_file(0, 0, "out")
-
-    assert (path / "main.csv").exists()
-    assert (path / "main.meta").exists()
-
-    dataframe = pd.read_csv(path / "main.csv")
-    with open(path / "main.meta", "r") as meta_file:
-        metadata = yaml.load(meta_file, Loader=yaml.FullLoader)
-
-    assert np.allclose(dataframe.values, individual.dataframe.values)
-    assert metadata == [m.to_dict() for m in individual.metadata]
-
-    os.system("rm -r out")
+    os.system("rm -r .testcache")

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -160,7 +160,7 @@ def test_tuple_limits(row_limits, col_limits, weights):
 def test_to_and_from_file(row_limits, col_limits, weights):
     """ Test that an individual can be saved to and created from file. """
 
-    root = Path(".testcache")
+    path = Path(".testcache/individual")
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -169,11 +169,11 @@ def test_to_and_from_file(row_limits, col_limits, weights):
         row_limits, col_limits, families, weights
     )
 
-    individual.to_file(0, 0, root)
-    assert (root / "0/0/main.csv").exists()
-    assert (root / "0/0/main.meta").exists()
+    individual.to_file(path, ".testcache")
+    assert (path / "main.csv").exists()
+    assert (path / "main.meta").exists()
 
-    saved_individual = Individual.from_file(distributions, 0, 0, root)
+    saved_individual = Individual.from_file(path, distributions, ".testcache")
 
     assert np.allclose(
         saved_individual.dataframe.values, individual.dataframe.values

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -35,9 +35,7 @@ def test_integer_limits(row_limits, col_limits, weights, prob):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
 
     mutant = mutation(
         individual, prob, row_limits, col_limits, families, weights
@@ -57,9 +55,7 @@ def test_integer_tuple_limits(row_limits, col_limits, weights, prob):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
 
     mutant = mutation(
         individual, prob, row_limits, col_limits, families, weights
@@ -88,9 +84,7 @@ def test_tuple_integer_limits(row_limits, col_limits, weights, prob):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
 
     mutant = mutation(
         individual, prob, row_limits, col_limits, families, weights
@@ -119,9 +113,7 @@ def test_tuple_limits(row_limits, col_limits, weights, prob):
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
 
-    individual = create_individual(
-        row_limits, col_limits, families, weights
-    )
+    individual = create_individual(row_limits, col_limits, families, weights)
 
     mutant = mutation(
         individual, prob, row_limits, col_limits, families, weights

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -555,9 +555,14 @@ def test_get_pop_history(
                 pop_ind.dataframe.values, individual.dataframe.values.compute()
             )
 
-            for ind_meta, pop_ind_meta in zip(individual.metadata, pop_ind.metadata):
+            for ind_meta, pop_ind_meta in zip(
+                individual.metadata, pop_ind.metadata
+            ):
                 assert ind_meta.family.name == pop_ind_meta.family.name
-                assert ind_meta.family.distribution is pop_ind_meta.family.distribution
+                assert (
+                    ind_meta.family.distribution
+                    is pop_ind_meta.family.distribution
+                )
                 assert ind_meta.to_dict() == pop_ind_meta.to_dict()
 
     os.system("rm -r .testcache")
@@ -794,10 +799,13 @@ def test_run_on_disk_serial(
             assert len(metadata) == len(dataframe.columns)
 
             for pdf in metadata:
-                assert sum(
-                    pdf.family.distribution is family.distribution
-                    for family in families
-                ) == 1
+                assert (
+                    sum(
+                        pdf.family.distribution is family.distribution
+                        for family in families
+                    )
+                    == 1
+                )
 
 
 @OPTIMISER
@@ -864,10 +872,13 @@ def test_run_on_disk_parallel(
             assert len(metadata) == len(dataframe.columns)
 
             for pdf in metadata:
-                assert sum(
-                    pdf.family.distribution is family.distribution
-                    for family in families
-                ) == 1
+                assert (
+                    sum(
+                        pdf.family.distribution is family.distribution
+                        for family in families
+                    )
+                    == 1
+                )
 
 
 @OPTIMISER

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -110,8 +110,8 @@ def test_init(
     assert do.generation == 0
     assert do.population is None
     assert do.pop_fitness is None
-    assert do.pop_history is None
-    assert do.fit_history is None
+    assert do.pop_history == []
+    assert do.fit_history.equals(pd.DataFrame())
 
     assert edo.cache == {}
 
@@ -327,15 +327,13 @@ def test_update_pop_history(
     )
 
     do._initialise_run(4)
-    assert do.pop_history is None
-
     do._update_pop_history()
     assert len(do.pop_history) == 1
     assert len(do.pop_history[0]) == size
     for i, individual in enumerate(do.population):
         hist_ind = do.pop_history[0][i]
         assert hist_ind.dataframe.equals(individual.dataframe)
-        assert hist_ind.metadata == individual.to_history().metadata
+        assert hist_ind.metadata == individual.metadata
 
 
 @OPTIMISER
@@ -374,8 +372,6 @@ def test_update_fit_history(
     )
 
     do._initialise_run(4)
-    assert do.fit_history is None
-
     do._update_fit_history()
     fit_history = do.fit_history
     assert fit_history.shape == (size, 3)
@@ -735,9 +731,7 @@ def test_run_serial(
             assert len(metadata) == len(dataframe.columns)
 
             for pdf in metadata:
-                assert pdf["name"] in [
-                    distribution.name for distribution in distributions
-                ]
+                assert sum(pdf.family is family for family in families) == 1
 
 
 @OPTIMISER
@@ -797,9 +791,7 @@ def test_run_parallel(
             assert len(metadata) == len(dataframe.columns)
 
             for pdf in metadata:
-                assert pdf["name"] in [
-                    distribution.name for distribution in distributions
-                ]
+                assert sum(pdf.family is family for family in families)
 
 
 @OPTIMISER

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -2,7 +2,6 @@
 
 import itertools as it
 import os
-from collections import defaultdict
 from pathlib import Path
 
 import dask.dataframe as dd
@@ -474,72 +473,7 @@ def test_write_generation_serial(
     )
 
     do._initialise_run(4)
-    do._write_generation(root=".testcache", processes=None)
-    path = Path(".testcache")
-
-    assert (path / "fitness.csv").exists()
-    fit = pd.read_csv(path / "fitness.csv")
-    assert list(fit.columns) == ["fitness", "generation", "individual"]
-    assert list(fit.dtypes) == [float, int, int]
-    assert list(fit["generation"].unique()) == [0]
-    assert list(fit["individual"]) == list(range(size))
-    assert np.allclose(fit["fitness"].values, do.pop_fitness)
-
-    path /= "0"
-    for i, ind in enumerate(do.population):
-        ind_path = path / str(i)
-        assert (ind_path / "main.csv").exists()
-        assert (ind_path / "main.meta").exists()
-
-        df = pd.read_csv(ind_path / "main.csv")
-        with open(ind_path / "main.meta", "r") as meta_file:
-            meta = yaml.load(meta_file, Loader=yaml.FullLoader)
-
-        assert np.allclose(df.values, ind.dataframe.values)
-        assert meta == [m.to_dict() for m in ind.metadata]
-
-    os.system("rm -r .testcache")
-
-
-@OPTIMISER
-@settings(max_examples=30)
-def test_write_generation_parallel(
-    size,
-    row_limits,
-    col_limits,
-    distributions,
-    weights,
-    max_iter,
-    best_prop,
-    lucky_prop,
-    crossover_prob,
-    mutation_prob,
-    shrinkage,
-    maximise,
-):
-    """ Test that the DataOptimiser can write a generation and its fitness to
-    file using multiple cores in parallel. """
-
-    families = [edo.Family(dist) for dist in distributions]
-
-    do = DataOptimiser(
-        trivial_fitness,
-        size,
-        row_limits,
-        col_limits,
-        families,
-        weights,
-        max_iter,
-        best_prop,
-        lucky_prop,
-        crossover_prob,
-        mutation_prob,
-        shrinkage,
-        maximise,
-    )
-
-    do._initialise_run(4)
-    do._write_generation(root=".testcache", processes=None)
+    do._write_generation(root=".testcache")
     path = Path(".testcache")
 
     assert (path / "fitness.csv").exists()
@@ -603,9 +537,9 @@ def test_get_pop_history(
     )
 
     do._initialise_run(4)
-    do._write_generation(root=".testcache", processes=4)
+    do._write_generation(root=".testcache")
 
-    pop_history = _get_pop_history(".testcache", 1)
+    pop_history = _get_pop_history(".testcache", 1, distributions)
     assert isinstance(pop_history, list)
     for generation in pop_history:
 
@@ -613,14 +547,18 @@ def test_get_pop_history(
         for i, individual in enumerate(generation):
 
             pop_ind = do.population[i]
+            assert isinstance(individual, Individual)
             assert isinstance(individual.dataframe, dd.DataFrame)
+            assert isinstance(individual.metadata, list)
+
             assert np.allclose(
                 pop_ind.dataframe.values, individual.dataframe.values.compute()
             )
-            assert isinstance(individual.metadata, list)
-            assert individual.metadata == [
-                m.to_dict() for m in pop_ind.metadata
-            ]
+
+            for ind_meta, pop_ind_meta in zip(individual.metadata, pop_ind.metadata):
+                assert ind_meta.family.name == pop_ind_meta.family.name
+                assert ind_meta.family.distribution is pop_ind_meta.family.distribution
+                assert ind_meta.to_dict() == pop_ind_meta.to_dict()
 
     os.system("rm -r .testcache")
 
@@ -662,7 +600,7 @@ def test_get_fit_history(
     )
 
     do._initialise_run(4)
-    do._write_generation(root=".testcache", processes=4)
+    do._write_generation(root=".testcache")
 
     fit_history = _get_fit_history(".testcache")
     assert isinstance(fit_history, dd.DataFrame)
@@ -830,7 +768,7 @@ def test_run_on_disk_serial(
         maximise,
     )
 
-    pop_history, fit_history = do.run(root=".testcache", seed=size)
+    pop_history, fit_history = do.run(root=".testcache_serial", seed=size)
 
     assert isinstance(fit_history, dd.DataFrame)
     assert list(fit_history.columns) == ["fitness", "generation", "individual"]
@@ -841,6 +779,8 @@ def test_run_on_disk_serial(
     assert list(fit_history["individual"].unique().compute()) == list(
         range(size)
     )
+
+    os.system("rm -r .testcache_serial")
 
     for generation in pop_history:
         assert len(generation) == size
@@ -854,11 +794,10 @@ def test_run_on_disk_serial(
             assert len(metadata) == len(dataframe.columns)
 
             for pdf in metadata:
-                assert pdf["name"] in [
-                    distribution.name for distribution in distributions
-                ]
-
-    os.system("rm -r .testcache")
+                assert sum(
+                    pdf.family.distribution is family.distribution
+                    for family in families
+                ) == 1
 
 
 @OPTIMISER
@@ -897,7 +836,9 @@ def test_run_on_disk_parallel(
         maximise,
     )
 
-    pop_history, fit_history = do.run(root=".testcache", processes=4, seed=size)
+    pop_history, fit_history = do.run(
+        root=".testcache_parallel", processes=4, seed=size
+    )
 
     assert isinstance(fit_history, dd.DataFrame)
     assert list(fit_history.columns) == ["fitness", "generation", "individual"]
@@ -908,6 +849,8 @@ def test_run_on_disk_parallel(
     assert list(fit_history["individual"].unique().compute()) == list(
         range(size)
     )
+
+    os.system("rm -r .testcache_parallel")
 
     for generation in pop_history:
         assert len(generation) == size
@@ -921,11 +864,10 @@ def test_run_on_disk_parallel(
             assert len(metadata) == len(dataframe.columns)
 
             for pdf in metadata:
-                assert pdf["name"] in [
-                    distribution.name for distribution in distributions
-                ]
-
-    os.system("rm -r .testcache")
+                assert sum(
+                    pdf.family.distribution is family.distribution
+                    for family in families
+                ) == 1
 
 
 @OPTIMISER
@@ -966,7 +908,7 @@ def test_run_is_reproducible(
     )
 
     pop_history_one, fit_history_one = do_one.run(
-        processes=4, seed=size, arg=None
+        processes=4, seed=size, kwargs={"arg": None}
     )
 
     families = [edo.Family(dist) for dist in distributions]

--- a/tests/test_shrink.py
+++ b/tests/test_shrink.py
@@ -34,4 +34,7 @@ def test_shrink(
     families = shrink(parents, families, itr, compact_ratio)
 
     for family in families:
-        assert family.distribution.param_limits.keys() == vars(family.make_instance()).keys()
+        assert (
+            family.distribution.param_limits.keys()
+            == vars(family.make_instance()).keys()
+        )


### PR DESCRIPTION
This PR moves some of the internal functionality away from the `Distribution` class and into the dynamic `<Family.distribution.name>Subtype` type. Namely:

- Individuals are saved using `pandas.DataFrame.to_csv` and `json.dump` for the dataframe and metadata respectively.
- The `Subtype` instances in `Individual.metadata` are converted to dictionaries that can be restored.

Example:

```python
>>> import numpy as np
>>> import pandas as pd
>>> 
>>> from edo import Family
>>> from edo.distributions import Uniform, Poisson
>>> from edo.individual import Individual
>>> 
>>> np.random.seed(0)
>>> distributions = [Uniform, Poisson]
>>> families = [Family(dist) for dist in distributions]
>>> 
>>> metadata = [family.make_instance() for family in families]
>>> dataframe = pd.DataFrame({i: meta.sample(5) for i, meta in enumerate(metadata)})
>>> individual = Individual(dataframe, metadata)
>>> 
>>> individual.to_file("individual/")
PosixPath('individual')
>>> 
>>> saved = Individual.from_file(distributions, "individual/")
>>> 
>>> np.allclose(saved.dataframe.values, individual.dataframe.values)
True
>>> saved.metadata, individual.metadata
([Uniform(bounds=[0.98, 4.3]), Poisson(lam=6.03)],
 [Uniform(bounds=[0.98, 4.3]), Poisson(lam=6.03)])
```