### PR TITLE
Allow more than ten subtypes in `Family.load()`

### DIFF
--- a/src/edo/family.py
+++ b/src/edo/family.py
@@ -133,7 +133,7 @@ class Family:
             family.random_state = pickle.load(state)
 
         subtype_paths = sorted(
-            path.glob(r"[0-9].pkl"), key=lambda p: int(p.stem)
+            path.glob(r"[0-9]*.pkl"), key=lambda p: int(p.stem)
         )
         for path in subtype_paths:
 


### PR DESCRIPTION
The previous regex only matched `0.pkl` to `9.pkl` in `Family.load()`. This adds a wildcard to allow for any number of subtypes to be recovered.