### PR TITLE
Update formatting (black, isort, flake8)

### DIFF
--- a/docs/src/crossover_example.py
+++ b/docs/src/crossover_example.py
@@ -35,7 +35,7 @@ df, meta = offspring
 
 df.to_csv("../discussion/operators/offspring.csv")
 
-with open(f"../discussion/operators/offspring.rst", "w") as ind_file:
+with open("../discussion/operators/offspring.rst", "w") as ind_file:
     string = ".. :orphan:\n\n"
     string += "With the following metadata::\n\n    ["
     for col in meta:

--- a/docs/src/tutorial_i.py
+++ b/docs/src/tutorial_i.py
@@ -12,8 +12,8 @@ def x_squared(df):
 
 
 def main():
-    """ Run the GA in the first tutorial and generate a plot of all fitness
-    scores in each epoch against the theoretical fitness function. """
+    """Run the GA in the first tutorial and generate a plot of all fitness
+    scores in each epoch against the theoretical fitness function."""
 
     pop, fit, all_pops, all_fits = edo.run_algorithm(
         fitness=x_squared,

--- a/docs/src/tutorial_ii.py
+++ b/docs/src/tutorial_ii.py
@@ -16,8 +16,8 @@ def squared_error(df, num_samples=50):
 
 
 def main():
-    """ Run the GA from the second tutorial and generate a plot of the fitness
-    progression. """
+    """Run the GA from the second tutorial and generate a plot of the fitness
+    progression."""
 
     pop, fit, all_pops, all_fits = edo.run_algorithm(
         fitness=squared_error,

--- a/docs/src/tutorial_iii.py
+++ b/docs/src/tutorial_iii.py
@@ -14,8 +14,8 @@ def determination(df):
 
 
 def main():
-    """ Run the GA in the third tutorial and generate plots for the fitness
-    progression and of the best individual in the final population. """
+    """Run the GA in the third tutorial and generate plots for the fitness
+    progression and of the best individual in the final population."""
 
     pop, fit, all_pops, all_fits = edo.run_algorithm(
         fitness=determination,

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - pytest-cov=2.10.0
   - scipy>=1.5
   - pip:
-    - black==19.10b0
-    - flake8==3.8.3
+    - black
+    - flake8
     - hypothesis==5.20.3
-    - isort==5.1.4
+    - isort

--- a/src/edo/distributions/base.py
+++ b/src/edo/distributions/base.py
@@ -4,8 +4,8 @@ import abc
 
 
 class Distribution(metaclass=abc.ABCMeta):
-    """ An abstract base class for all currently implemented distributions and
-    those defined by users. """
+    """An abstract base class for all currently implemented distributions and
+    those defined by users."""
 
     @abc.abstractmethod
     def sample(self, nrows=None, random_state=None):

--- a/src/edo/distributions/continuous.py
+++ b/src/edo/distributions/continuous.py
@@ -4,7 +4,7 @@ from .base import Distribution
 
 
 class Gamma(Distribution):
-    """ The gamma distribution class.
+    """The gamma distribution class.
 
     Parameters
     ----------
@@ -45,8 +45,8 @@ class Gamma(Distribution):
         return f"Gamma(alpha={alpha}, theta={theta})"
 
     def sample(self, nrows, random_state):
-        """ Take a sample of size ``nrows`` from the gamma distribution using
-        the provided ``np.random.RandomState`` instance. """
+        """Take a sample of size ``nrows`` from the gamma distribution using
+        the provided ``np.random.RandomState`` instance."""
 
         return random_state.gamma(
             shape=self.alpha, scale=self.theta, size=nrows
@@ -54,7 +54,7 @@ class Gamma(Distribution):
 
 
 class Normal(Distribution):
-    """ The normal distribution class.
+    """The normal distribution class.
 
     Parameters
     ----------
@@ -94,14 +94,14 @@ class Normal(Distribution):
         return f"Normal(mean={mean}, std={std})"
 
     def sample(self, nrows, random_state):
-        """ Take a sample of size ``nrows`` from the normal distribution using
-        the provided ``np.random.RandomState`` instance. """
+        """Take a sample of size ``nrows`` from the normal distribution using
+        the provided ``np.random.RandomState`` instance."""
 
         return random_state.normal(loc=self.mean, scale=self.std, size=nrows)
 
 
 class Uniform(Distribution):
-    """ The uniform distribution class.
+    """The uniform distribution class.
 
     Parameters
     ----------
@@ -139,7 +139,7 @@ class Uniform(Distribution):
         return f"Uniform(bounds=[{lower}, {upper}])"
 
     def sample(self, nrows, random_state):
-        """ Take a sample of size ``nrows`` from the uniform distribution using
-        the provided ``np.random.RandomState`` instance. """
+        """Take a sample of size ``nrows`` from the uniform distribution using
+        the provided ``np.random.RandomState`` instance."""
 
         return random_state.uniform(*self.bounds, size=nrows)

--- a/src/edo/distributions/discrete.py
+++ b/src/edo/distributions/discrete.py
@@ -4,7 +4,7 @@ from .base import Distribution
 
 
 class Bernoulli(Distribution):
-    """ The Bernoulli distribution class, i.e. a binomial distribution with
+    """The Bernoulli distribution class, i.e. a binomial distribution with
     exactly one trial.
 
     Parameters
@@ -40,14 +40,14 @@ class Bernoulli(Distribution):
         return f"Bernoulli(prob={round(self.prob, 2)})"
 
     def sample(self, nrows, random_state):
-        """ Take a sample of size ``nrows`` from the Bernoulli distribution
-        using the provided ``np.random.RandomState`` instance. """
+        """Take a sample of size ``nrows`` from the Bernoulli distribution
+        using the provided ``np.random.RandomState`` instance."""
 
         return random_state.binomial(n=1, p=self.prob, size=nrows)
 
 
 class Poisson(Distribution):
-    """ The Poisson distribution class.
+    """The Poisson distribution class.
 
     Parameters
     ----------
@@ -82,7 +82,7 @@ class Poisson(Distribution):
         return f"Poisson(lam={round(self.lam, 2)})"
 
     def sample(self, nrows, random_state):
-        """ Take a sample of size ``nrows`` from the Poisson distribution
-        using the provided ``np.random.RandomState`` instance. """
+        """Take a sample of size ``nrows`` from the Poisson distribution
+        using the provided ``np.random.RandomState`` instance."""
 
         return random_state.poisson(lam=self.lam, size=nrows)

--- a/src/edo/family.py
+++ b/src/edo/family.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 class Family:
-    """ A class for handling all concurrent subtypes of a distribution class. A
+    """A class for handling all concurrent subtypes of a distribution class. A
     subtype is an independent copy of the distribution class allowing more of
     the search space to be explored.
 
@@ -55,8 +55,8 @@ class Family:
         return f"{self.name}(subtypes={self.subtype_id})"
 
     def add_subtype(self, subtype_name=None, attributes=None):
-        """ Create a copy of the distribution class that is identical and
-        independent of the original. """
+        """Create a copy of the distribution class that is identical and
+        independent of the original."""
 
         if subtype_name is None:
             subtype_name = f"{self.distribution.name}Subtype"
@@ -74,8 +74,8 @@ class Family:
         self.subtype_id += 1
 
     def make_instance(self, random_state):
-        """ Select an existing subtype at random -- or create a new one if there
-        is space available -- and return an instance of that subtype. """
+        """Select an existing subtype at random -- or create a new one if there
+        is space available -- and return an instance of that subtype."""
 
         choices = list(self.subtypes)
         if self.max_subtypes is None or len(choices) < self.max_subtypes:
@@ -89,8 +89,8 @@ class Family:
         return instance
 
     def save(self, root=".edocache"):
-        """ Save the current subtypes in the family and the family's random
-        state in the ``root`` directory. """
+        """Save the current subtypes in the family and the family's random
+        state in the ``root`` directory."""
 
         path = pathlib.Path(f"{root}/subtypes/{self.distribution.name}")
         path.mkdir(exist_ok=True, parents=True)
@@ -107,9 +107,9 @@ class Family:
                 pickle.dump(attributes, sub, protocol=pickle.HIGHEST_PROTOCOL)
 
     def reset(self, root=None):
-        """ Reset the family to have no subtypes and the default ``numpy`` PRNG.
+        """Reset the family to have no subtypes and the default ``numpy`` PRNG.
         If ``root`` is passed then any cached information about the family is
-        deleted. """
+        deleted."""
 
         self.subtype_id = 0
         self.subtypes.clear()
@@ -121,9 +121,9 @@ class Family:
 
     @classmethod
     def load(cls, distribution, root=".edocache"):
-        """ Load in any existing cached subtype dictionaries for
+        """Load in any existing cached subtype dictionaries for
         ``distribution`` and restore the subtype along with the family's random
-        state. """
+        state."""
 
         family = Family(distribution)
         name = distribution.name
@@ -160,8 +160,8 @@ def _get_attrs_for_subtype(obj):
 
 
 def _subtype_to_dict(self):
-    """ Convert an unpickleable subtype instance to a dictionary so it can be
-    recovered at a later date. """
+    """Convert an unpickleable subtype instance to a dictionary so it can be
+    recovered at a later date."""
 
     attributes = {"name": self.name, "subtype_id": self.subtype_id}
 

--- a/src/edo/fitness.py
+++ b/src/edo/fitness.py
@@ -17,9 +17,9 @@ def get_fitness(individual, fitness, **kwargs):
 
 
 def get_population_fitness(population, fitness, processes=None, **kwargs):
-    """ Return the fitness of each individual in the population. This can be
+    """Return the fitness of each individual in the population. This can be
     done in parallel by specifying a number of cores to use for independent
-    processes. """
+    processes."""
 
     tasks = (
         get_fitness(individual, fitness, **kwargs) for individual in population

--- a/src/edo/individual.py
+++ b/src/edo/individual.py
@@ -12,7 +12,7 @@ from .family import Family
 
 
 class Individual:
-    """ A class to represent an individual in the EA.
+    """A class to represent an individual in the EA.
 
     Parameters
     ----------
@@ -56,9 +56,9 @@ class Individual:
     def from_file(
         cls, path, distributions, family_root=".edocache", method="pandas"
     ):
-        """ Create an instance of ``Individual`` from the files at ``path`` and
+        """Create an instance of ``Individual`` from the files at ``path`` and
         ``family_root`` using either ``pandas`` or ``dask`` to read in
-        individuals. Always fall back on ``pandas``. """
+        individuals. Always fall back on ``pandas``."""
 
         path = Path(path)
         distributions = {dist.name: dist for dist in distributions}
@@ -135,8 +135,8 @@ def _sample_ncols(col_limits, random_state):
 def _get_minimum_columns(
     nrows, col_limits, families, family_counts, random_state
 ):
-    """ If ``col_limits`` has a tuple lower limit then sample columns of the
-    corresponding element of ``families`` as needed to satisfy this bound. """
+    """If ``col_limits`` has a tuple lower limit then sample columns of the
+    corresponding element of ``families`` as needed to satisfy this bound."""
 
     columns, metadata = [], []
     for family, min_limit in zip(families, col_limits[0]):
@@ -160,9 +160,9 @@ def _get_remaining_columns(
     family_counts,
     random_state,
 ):
-    """ Sample all remaining columns for the current individual. If
+    """Sample all remaining columns for the current individual. If
     ``col_limits`` has a tuple upper limit then sample all remaining
-    columns for the individual without exceeding the bounds. """
+    columns for the individual without exceeding the bounds."""
 
     while len(columns) < ncols:
         family = random_state.choice(families, p=weights)
@@ -183,7 +183,7 @@ def _get_remaining_columns(
 
 
 def create_individual(row_limits, col_limits, families, weights, random_state):
-    """ Create an individual within the limits provided.
+    """Create an individual within the limits provided.
 
     Parameters
     ----------

--- a/src/edo/operators/crossover.py
+++ b/src/edo/operators/crossover.py
@@ -8,9 +8,9 @@ from .util import get_family_counts
 
 
 def _collate_parents(parent1, parent2):
-    """ Collect the columns and metadata from each parent together. These lists
+    """Collect the columns and metadata from each parent together. These lists
     form a pool from which information is inherited during the crossover
-    process. """
+    process."""
 
     parent_cols, parent_meta = [], []
     for dataframe, metadata in [parent1, parent2]:
@@ -23,9 +23,9 @@ def _collate_parents(parent1, parent2):
 def _cross_minimum_columns(
     parent_cols, parent_meta, col_limits, families, random_state
 ):
-    """ In the case where ``col_limits`` has a tuple lower limit, inherit the
+    """In the case where ``col_limits`` has a tuple lower limit, inherit the
     minimum number of columns from two parents to satisfy this limit. Return
-    part of a whole individual and the adjusted parent information. """
+    part of a whole individual and the adjusted parent information."""
 
     columns, metadata = [], []
     for limit, family in zip(col_limits[0], families):
@@ -54,9 +54,9 @@ def _cross_remaining_columns(
     families,
     random_state,
 ):
-    """ Regardless of whether ``col_limits`` has a tuple upper limit or not,
+    """Regardless of whether ``col_limits`` has a tuple upper limit or not,
     inherit all remaining columns from the two parents so as not to exceed this
-    upper bound. Return the components of a full individual. """
+    upper bound. Return the components of a full individual."""
 
     family_counts = get_family_counts(metadata, families)
     while len(columns) < ncols:
@@ -103,7 +103,7 @@ def _adjust_column_lengths(columns, metadata, nrows, random_state):
 
 
 def crossover(parent1, parent2, col_limits, families, random_state, prob=0.5):
-    """ Blend the information from two parents to create a new ``Individual``.
+    """Blend the information from two parents to create a new ``Individual``.
     Dimensions are inherited first, forming a "skeleton" that is filled with
     column-metadata pairs. These pairs are selected from either parent
     uniformly. Missing values are filled in as necessary.

--- a/src/edo/operators/mutation.py
+++ b/src/edo/operators/mutation.py
@@ -6,7 +6,7 @@ from .util import get_family_counts
 
 
 def mutation(individual, prob, row_limits, col_limits, families, weights=None):
-    """ Mutate an individual. Here, the characteristics of an individual can be
+    """Mutate an individual. Here, the characteristics of an individual can be
     split into two parts: their dimensions, and their values. Each of these
     parts is mutated in a different way using the same probability,
     ``prob``.
@@ -48,9 +48,9 @@ def mutation(individual, prob, row_limits, col_limits, families, weights=None):
 
 
 def mutate_nrows(dataframe, metadata, row_limits, random_state, prob):
-    """ Mutate the number of rows an individual has by adding a new row and/or
+    """Mutate the number of rows an individual has by adding a new row and/or
     dropping a row at random so as not to exceed the bounds of
-    ``row_limits``. """
+    ``row_limits``."""
 
     if random_state.random() < prob and dataframe.shape[0] < row_limits[1]:
         dataframe = _add_row(dataframe, metadata, random_state)
@@ -64,9 +64,9 @@ def mutate_nrows(dataframe, metadata, row_limits, random_state, prob):
 def mutate_ncols(
     dataframe, metadata, col_limits, families, weights, random_state, prob
 ):
-    """ Mutate the number of columns an individual has by adding a new column
+    """Mutate the number of columns an individual has by adding a new column
     and/or dropping a column at random. In either case, the bounds defined in
-    ``col_limits`` cannot be exceeded. """
+    ``col_limits`` cannot be exceeded."""
 
     if isinstance(col_limits[1], tuple):
         condition = dataframe.shape[1] < sum(col_limits[1])
@@ -92,9 +92,9 @@ def mutate_ncols(
 
 
 def mutate_values(dataframe, metadata, random_state, prob):
-    """ Iterate over the values of ``dataframe`` and mutate them each with
+    """Iterate over the values of ``dataframe`` and mutate them each with
     probability ``prob``. Mutating a value is done by resampling from the
-    associated column distribution in ``metadata``. """
+    associated column distribution in ``metadata``."""
 
     for j, col in enumerate(dataframe.columns):
         pdf = metadata[j]
@@ -107,8 +107,8 @@ def mutate_values(dataframe, metadata, random_state, prob):
 
 
 def _rename(dataframe):
-    """ Rename columns or reindex to make sense after deletion or addition of a
-    new line. """
+    """Rename columns or reindex to make sense after deletion or addition of a
+    new line."""
 
     dataframe = dataframe.reset_index(drop=True)
     dataframe.columns = (i for i, _ in enumerate(dataframe.columns))
@@ -116,8 +116,8 @@ def _rename(dataframe):
 
 
 def _add_row(dataframe, metadata, random_state):
-    """ Append a row to the dataframe by sampling values from each column's
-    distribution. """
+    """Append a row to the dataframe by sampling values from each column's
+    distribution."""
 
     dataframe = dataframe.append(
         {i: pdf.sample(1, random_state)[0] for i, pdf in enumerate(metadata)},
@@ -136,9 +136,9 @@ def _remove_row(dataframe, random_state):
 
 
 def _add_col(dataframe, metadata, col_limits, families, weights, random_state):
-    """ Add a new column to the end of the dataframe by sampling a distribution
+    """Add a new column to the end of the dataframe by sampling a distribution
     from ``families`` according to the column limits and distribution weights
-    and sampling the required number of values from that distribution. """
+    and sampling the required number of values from that distribution."""
 
     nrows, ncols = dataframe.shape
     if isinstance(col_limits[1], tuple):

--- a/src/edo/operators/selection.py
+++ b/src/edo/operators/selection.py
@@ -6,7 +6,7 @@ import numpy as np
 def selection(
     population, pop_fitness, best_prop, lucky_prop, random_state, maximise=False
 ):
-    """ Given a population, select a proportion of the "best" individuals and
+    """Given a population, select a proportion of the "best" individuals and
     another of the "lucky" individuals (if they are available) to form a set of
     potential parents.
 

--- a/src/edo/operators/shrink.py
+++ b/src/edo/operators/shrink.py
@@ -2,8 +2,8 @@
 
 
 def _get_param_values(parents, subtype, name):
-    """ Get the parameter values from the parents for a particular distribution
-    subtype parameter. """
+    """Get the parameter values from the parents for a particular distribution
+    subtype parameter."""
 
     values = []
     for _, metadata in parents:
@@ -19,7 +19,7 @@ def _get_param_values(parents, subtype, name):
 
 
 def _adjust_subtype_param_limits(parents, subtype, itr, shrinkage):
-    r""" Adjust the search space of a distribution subtype's parameters
+    r"""Adjust the search space of a distribution subtype's parameters
     according to a power law on its limits:
 
     .. math::
@@ -46,7 +46,7 @@ def _adjust_subtype_param_limits(parents, subtype, itr, shrinkage):
 
 
 def shrink(parents, families, itr, shrinkage):
-    """ Given the current progress of the evolutionary algorithm, shrink its
+    """Given the current progress of the evolutionary algorithm, shrink its
     search space, i.e. the parameter spaces for each of the distribution classes
     in ``families``.
 

--- a/src/edo/operators/util.py
+++ b/src/edo/operators/util.py
@@ -2,8 +2,8 @@
 
 
 def get_family_counts(metadata, families):
-    """ Get the number of instances in `metadata` that belong to each family in
-    `families`. """
+    """Get the number of instances in `metadata` that belong to each family in
+    `families`."""
 
     return {
         family: sum([pdf.family is family for pdf in metadata])

--- a/src/edo/optimiser.py
+++ b/src/edo/optimiser.py
@@ -14,7 +14,7 @@ from edo.population import create_initial_population, create_new_population
 
 
 class DataOptimiser:
-    """ The (evolutionary) dataset optimiser. A class that generates data for a
+    """The (evolutionary) dataset optimiser. A class that generates data for a
     given fitness function and evolutionary parameters.
 
     Parameters
@@ -100,12 +100,12 @@ class DataOptimiser:
         self.fit_history = pd.DataFrame()
 
     def stop(self, **kwargs):
-        """ A placeholder for a function which acts as a stopping condition on
-        the EA. """
+        """A placeholder for a function which acts as a stopping condition on
+        the EA."""
 
     def dwindle(self, **kwargs):
-        """ A placeholder for a function which can adjust (typically, reduce)
-        the mutation probability over the run of the EA. """
+        """A placeholder for a function which can adjust (typically, reduce)
+        the mutation probability over the run of the EA."""
 
     def run(
         self,
@@ -116,7 +116,7 @@ class DataOptimiser:
         stop_kwargs=None,
         dwindle_kwargs=None,
     ):
-        """ Run the evolutionary algorithm under the given constraints.
+        """Run the evolutionary algorithm under the given constraints.
 
         Parameters
         ----------
@@ -215,8 +215,8 @@ class DataOptimiser:
         )
 
     def _get_next_generation(self, processes, **kwargs):
-        """ Create the next population via selection, crossover and mutation,
-        update the family subtypes and get the new population's fitness. """
+        """Create the next population via selection, crossover and mutation,
+        update the family subtypes and get the new population's fitness."""
 
         parents = selection(
             self.population,
@@ -271,8 +271,8 @@ class DataOptimiser:
         )
 
     def _write_generation(self, root):
-        """ Write all individuals in a generation and their collective fitnesses
-        to file at the generation's directory in `root`. """
+        """Write all individuals in a generation and their collective fitnesses
+        to file at the generation's directory in `root`."""
 
         write_fitness(self.pop_fitness, self.generation, root)
         for idx, individual in enumerate(self.population):
@@ -288,8 +288,8 @@ class DataOptimiser:
             self._write_generation(root)
 
     def _get_current_subtypes(self, parents):
-        """ Get a dictionary mapping each family to all the subtype IDs that are
-        present in the parents. """
+        """Get a dictionary mapping each family to all the subtype IDs that are
+        present in the parents."""
 
         family_to_subtype_ids = defaultdict(list)
         for parent in parents:
@@ -303,8 +303,8 @@ class DataOptimiser:
         return family_to_subtype_ids
 
     def _update_subtypes(self, parents):
-        """ Update the current subtypes for each family to be those present in
-        the parents. """
+        """Update the current subtypes for each family to be those present in
+        the parents."""
 
         current_subtypes = self._get_current_subtypes(parents)
         for family, current_ids in current_subtypes.items():
@@ -315,9 +315,9 @@ class DataOptimiser:
 
 
 def _get_pop_history(root, generation, distributions):
-    """ Read in the individuals from each generation. The dataset is given
+    """Read in the individuals from each generation. The dataset is given
     as a `dask.dataframe.core.DataFrame` but the metadata are recovered
-    instances of their original class subtypes. """
+    instances of their original class subtypes."""
 
     pop_history = []
     for gen in range(generation):
@@ -340,7 +340,7 @@ def _get_pop_history(root, generation, distributions):
 
 
 def _get_fit_history(root):
-    """ Read in the fitness history from each generation in a run  as a
-    `dask.dataframe.core.DataFrame`. """
+    """Read in the fitness history from each generation in a run  as a
+    `dask.dataframe.core.DataFrame`."""
 
     return dd.read_csv(f"{root}/fitness.csv")

--- a/src/edo/population.py
+++ b/src/edo/population.py
@@ -7,7 +7,7 @@ from .operators import crossover, mutation
 def create_initial_population(
     row_limits, col_limits, families, weights, random_states
 ):
-    """ Create an initial population for the genetic algorithm based on the
+    """Create an initial population for the genetic algorithm based on the
     given parameters.
 
     Parameters
@@ -54,7 +54,7 @@ def create_new_population(
     weights,
     random_states,
 ):
-    """ Given a set of potential parents to be carried into the next generation,
+    """Given a set of potential parents to be carried into the next generation,
     create offspring from pairs within that set until there are enough
     individuals.
 

--- a/tests/distributions/test_common.py
+++ b/tests/distributions/test_common.py
@@ -54,8 +54,8 @@ def test_repr(distribution, seed):
 
 @params
 def test_set_param_limits(distribution, seed):
-    """ Check distribution classes can have their default parameter limits
-    changed. """
+    """Check distribution classes can have their default parameter limits
+    changed."""
 
     param_limits = dict(distribution.param_limits)
     for param_name in distribution.param_limits:

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -21,8 +21,8 @@ CONTINUOUS = given(
 
 @CONTINUOUS
 def test_gamma_set_param_limits(first_limits, second_limits, seed):
-    """ Check that a Gamma object can sample its parameters correctly if its
-    class attributes are altered. """
+    """Check that a Gamma object can sample its parameters correctly if its
+    class attributes are altered."""
 
     Gamma.param_limits = {"alpha": first_limits, "theta": second_limits}
 
@@ -34,8 +34,8 @@ def test_gamma_set_param_limits(first_limits, second_limits, seed):
 
 @CONTINUOUS
 def test_normal_set_param_limits(first_limits, second_limits, seed):
-    """ Check that a Normal object can sample its parameters correctly if its
-    class attributes are altered. """
+    """Check that a Normal object can sample its parameters correctly if its
+    class attributes are altered."""
 
     Normal.param_limits = {"mean": first_limits, "std": second_limits}
 
@@ -48,8 +48,8 @@ def test_normal_set_param_limits(first_limits, second_limits, seed):
 
 @CONTINUOUS
 def test_uniform_set_param_limits(first_limits, second_limits, seed):
-    """ Check that a Uniform object can sample its parameters correctly if its
-    class attributes are altered. """
+    """Check that a Uniform object can sample its parameters correctly if its
+    class attributes are altered."""
 
     Uniform.param_limits = {"bounds": first_limits}
 

--- a/tests/distributions/test_discrete.py
+++ b/tests/distributions/test_discrete.py
@@ -22,8 +22,8 @@ LIMITS = (
     seed=integers(min_value=0, max_value=2 ** 32 - 1),
 )
 def test_bernoulli_set_param_limits(prob_limits, seed):
-    """ Check that a Bernoulli object can sample its parameters correctly if its
-    class attributes are altered. """
+    """Check that a Bernoulli object can sample its parameters correctly if its
+    class attributes are altered."""
 
     Bernoulli.param_limits = {"prob": prob_limits}
 
@@ -34,8 +34,8 @@ def test_bernoulli_set_param_limits(prob_limits, seed):
 
 @given(lam_limits=LIMITS, seed=integers(min_value=0, max_value=2 ** 32 - 1))
 def test_poisson_set_param_limits(lam_limits, seed):
-    """ Check that a Poisson object can sample its parameters correctly if its
-    class attributes are altered. """
+    """Check that a Poisson object can sample its parameters correctly if its
+    class attributes are altered."""
 
     Poisson.param_limits = {"lam": lam_limits}
 

--- a/tests/test_crossover.py
+++ b/tests/test_crossover.py
@@ -44,8 +44,8 @@ def _common_asserts(individual, *parents):
 @INTEGER_CROSSOVER
 @settings(deadline=None)
 def test_integer_limits(row_limits, col_limits, weights, prob, seed):
-    """ Verify that `crossover` produces a valid individual with all integer
-    column limits. """
+    """Verify that `crossover` produces a valid individual with all integer
+    column limits."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -65,8 +65,8 @@ def test_integer_limits(row_limits, col_limits, weights, prob, seed):
 
 @INTEGER_TUPLE_CROSSOVER
 def test_integer_tuple_limits(row_limits, col_limits, weights, prob, seed):
-    """ Verify that `crossover` produces a valid individual where the lower and
-    upper column limits are integer and tuple respectively. """
+    """Verify that `crossover` produces a valid individual where the lower and
+    upper column limits are integer and tuple respectively."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -90,8 +90,8 @@ def test_integer_tuple_limits(row_limits, col_limits, weights, prob, seed):
 
 @TUPLE_INTEGER_CROSSOVER
 def test_tuple_integer_limits(row_limits, col_limits, weights, prob, seed):
-    """ Verify that `crossover` produces a valid individual where the lower and
-    upper column limits are tuple and integer respectively. """
+    """Verify that `crossover` produces a valid individual where the lower and
+    upper column limits are tuple and integer respectively."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -115,8 +115,8 @@ def test_tuple_integer_limits(row_limits, col_limits, weights, prob, seed):
 
 @TUPLE_CROSSOVER
 def test_tuple_limits(row_limits, col_limits, weights, prob, seed):
-    """ Verify that `crossover` produces a valid individual with all tuple
-    column limits. """
+    """Verify that `crossover` produces a valid individual with all tuple
+    column limits."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -14,16 +14,16 @@ from edo.distributions import Uniform
 
 
 class RadiusUniform(Uniform):
-    """ A Uniform child for capturing the radius of a point in the unit
-    circle. """
+    """A Uniform child for capturing the radius of a point in the unit
+    circle."""
 
     name = "RadiusUniform"
     param_limits = {"bounds": [0, 1]}
 
 
 class AngleUniform(Uniform):
-    """ A Uniform child for capturing the angle of a point in the unit
-    circle. """
+    """A Uniform child for capturing the angle of a point in the unit
+    circle."""
 
     name = "AngleUniform"
     param_limits = {"bounds": [-2 * np.pi, 2 * np.pi]}
@@ -72,9 +72,9 @@ def run_circle_example():
 @given(repetitions=integers())
 @settings(deadline=None, max_examples=10)
 def test_circle_example(repetitions):
-    """ Check that the circle example dataset never changes. If, for some
+    """Check that the circle example dataset never changes. If, for some
     reason, it changes (or needs to be changed) on purpose, then delete
-    `circle.csv` and run this test again. """
+    `circle.csv` and run this test again."""
 
     history = run_circle_example()
 
@@ -118,8 +118,8 @@ def run_sample_example():
 @given(repetitions=integers())
 @settings(deadline=None, max_examples=5)
 def test_sample_example(repetitions):
-    """ Check that the sample example dataset never changes (with the same
-    caveat as the circle example above). """
+    """Check that the sample example dataset never changes (with the same
+    caveat as the circle example above)."""
 
     history = run_sample_example()
 

--- a/tests/test_family.py
+++ b/tests/test_family.py
@@ -184,8 +184,8 @@ def test_load(distribution):
 @given(distribution=distributions())
 @settings(deadline=None)
 def test_load_more_than_ten(distribution):
-    """ Test that a family with more than 10 subtypes can be created from a
-    cache. """
+    """Test that a family with more than 10 subtypes can be created from a
+    cache."""
 
     family = Family(distribution)
     for _ in range(11):

--- a/tests/test_fitness.py
+++ b/tests/test_fitness.py
@@ -20,8 +20,8 @@ from .util.trivials import trivial_fitness
 
 @INTEGER_INDIVIDUAL
 def test_get_fitness(row_limits, col_limits, weights, seed):
-    """ Create an individual and get its fitness. Then verify that the fitness
-    is of the correct data type and has been added to the cache. """
+    """Create an individual and get its fitness. Then verify that the fitness
+    is of the correct data type and has been added to the cache."""
 
     distributions = [Normal, Poisson, Uniform]
     families = [edo.Family(dist) for dist in distributions]
@@ -38,9 +38,9 @@ def test_get_fitness(row_limits, col_limits, weights, seed):
 
 @INTEGER_INDIVIDUAL
 def test_get_fitness_kwargs(row_limits, col_limits, weights, seed):
-    """ Create an individual and get its fitness with keyword arguments. Then
+    """Create an individual and get its fitness with keyword arguments. Then
     verify that the fitness is of the correct data type and has been added to
-    the cache. """
+    the cache."""
 
     fitness_kwargs = {"arg": None}
     distributions = [Normal, Poisson, Uniform]
@@ -59,9 +59,9 @@ def test_get_fitness_kwargs(row_limits, col_limits, weights, seed):
 @POPULATION
 @settings(max_examples=30)
 def test_get_population_fitness_serial(size, row_limits, col_limits, weights):
-    """ Create a population and find its fitness serially. Verify that the
+    """Create a population and find its fitness serially. Verify that the
     fitness array is of the correct data type and size, and that they have each
-    been added to the cache. """
+    been added to the cache."""
 
     distributions = [Normal, Poisson, Uniform]
     families = [edo.Family(dist) for dist in distributions]
@@ -83,9 +83,9 @@ def test_get_population_fitness_serial(size, row_limits, col_limits, weights):
 def test_get_population_fitness_parallel(
     size, row_limits, col_limits, weights, processes
 ):
-    """ Create a population and find its fitness in parallel. Verify that the
+    """Create a population and find its fitness in parallel. Verify that the
     fitness array is of the correct data type and size, and that they have each
-    been added to the cache. """
+    been added to the cache."""
 
     distributions = [Normal, Poisson, Uniform]
     families = [edo.Family(dist) for dist in distributions]

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -49,9 +49,9 @@ def test_repr(dataframe, metadata):
 
 @INTEGER_INDIVIDUAL
 def test_integer_limits(row_limits, col_limits, weights, seed):
-    """ Create an individual with all-integer column limits and verify that it
+    """Create an individual with all-integer column limits and verify that it
     is a namedtuple with a `pandas.DataFrame` field of a valid shape, and
-    metadata made up of instances from the classes in families. """
+    metadata made up of instances from the classes in families."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -70,9 +70,9 @@ def test_integer_limits(row_limits, col_limits, weights, seed):
 
 @INTEGER_TUPLE_INDIVIDUAL
 def test_integer_tuple_limits(row_limits, col_limits, weights, seed):
-    """ Create an individual with integer lower limits and tuple upper limits on
+    """Create an individual with integer lower limits and tuple upper limits on
     the columns. Verify the individual is valid and of a reasonable shape and
-    does not exceed the upper bounds. """
+    does not exceed the upper bounds."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -96,9 +96,9 @@ def test_integer_tuple_limits(row_limits, col_limits, weights, seed):
 
 @TUPLE_INTEGER_INDIVIDUAL
 def test_tuple_integer_limits(row_limits, col_limits, weights, seed):
-    """ Create an individual with tuple lower limits and integer upper limits on
+    """Create an individual with tuple lower limits and integer upper limits on
     the columns. Verify the individual is valid and of a reasonable shape and
-    does not exceed the lower bounds. """
+    does not exceed the lower bounds."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -122,9 +122,9 @@ def test_tuple_integer_limits(row_limits, col_limits, weights, seed):
 
 @TUPLE_INDIVIDUAL
 def test_tuple_limits(row_limits, col_limits, weights, seed):
-    """ Create an individual with tuple column limits. Verify the individual is
+    """Create an individual with tuple column limits. Verify the individual is
     valid and of a reasonable shape and does not exceed either of the column
-    bounds. """
+    bounds."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -31,8 +31,8 @@ def _common_asserts(mutant, families):
 
 @INTEGER_MUTATION
 def test_integer_limits(row_limits, col_limits, weights, prob, seed):
-    """ Verify that `mutation` creates a valid individual with all integer
-    column limits. """
+    """Verify that `mutation` creates a valid individual with all integer
+    column limits."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -54,8 +54,8 @@ def test_integer_limits(row_limits, col_limits, weights, prob, seed):
 
 @INTEGER_TUPLE_MUTATION
 def test_integer_tuple_limits(row_limits, col_limits, weights, prob, seed):
-    """ Verify that `mutation` creates a valid individual where the lower and
-    upper column limits are integer and tuple respectively. """
+    """Verify that `mutation` creates a valid individual where the lower and
+    upper column limits are integer and tuple respectively."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -86,8 +86,8 @@ def test_integer_tuple_limits(row_limits, col_limits, weights, prob, seed):
 
 @TUPLE_INTEGER_MUTATION
 def test_tuple_integer_limits(row_limits, col_limits, weights, prob, seed):
-    """ Verify that `mutation` creates a valid individual where the lower and
-    upper column limits and tuple and integer respectively. """
+    """Verify that `mutation` creates a valid individual where the lower and
+    upper column limits and tuple and integer respectively."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -118,8 +118,8 @@ def test_tuple_integer_limits(row_limits, col_limits, weights, prob, seed):
 
 @TUPLE_MUTATION
 def test_tuple_limits(row_limits, col_limits, weights, prob, seed):
-    """ Verify that `mutation` creates a valid individual with all tuple column
-    limits. """
+    """Verify that `mutation` creates a valid individual with all tuple column
+    limits."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]

--- a/tests/test_optimiser.py
+++ b/tests/test_optimiser.py
@@ -455,8 +455,8 @@ def test_write_generation(
     shrinkage,
     maximise,
 ):
-    """ Test that the DataOptimiser can write a generation and its fitness to
-    file with a single core. """
+    """Test that the DataOptimiser can write a generation and its fitness to
+    file with a single core."""
 
     families = [edo.Family(dist) for dist in distributions]
 
@@ -906,8 +906,8 @@ def test_run_is_reproducible(
     shrinkage,
     maximise,
 ):
-    """ Test that two runs of the EA with the same parameters produce the
-    same population and fitness histories. """
+    """Test that two runs of the EA with the same parameters produce the
+    same population and fitness histories."""
 
     families = [edo.Family(dist) for dist in distributions]
 
@@ -969,8 +969,8 @@ def test_run_is_reproducible(
 )
 @settings(deadline=None, max_examples=10)
 def test_run_not_reproducible_without_seed(size, distributions, maximise):
-    """ Test that two runs of the EA with the same parameters will likely
-    produce different populations if they aren't seeded. """
+    """Test that two runs of the EA with the same parameters will likely
+    produce different populations if they aren't seeded."""
 
     row_limits = [10, 30]
     col_limits = [2, 5]

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -14,8 +14,8 @@ from .util.parameters import OFFSPRING, POPULATION
 
 @POPULATION
 def test_create_initial_population(size, row_limits, col_limits, weights):
-    """ Create an initial population of individuals and verify it is a list
-    of the correct length with valid individuals. """
+    """Create an initial population of individuals and verify it is a list
+    of the correct length with valid individuals."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]
@@ -57,9 +57,9 @@ def test_create_new_population(
     mutation_prob,
     maximise,
 ):
-    """ Create a population and use them to create a new proto-population
+    """Create a population and use them to create a new proto-population
     of offspring. Verify that each offspring is a valid individual and there are
-    the correct number of them. """
+    the correct number of them."""
 
     distributions = [Gamma, Normal, Poisson]
     families = [Family(distribution) for distribution in distributions]

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -18,8 +18,8 @@ from .util.trivials import trivial_fitness
 def test_selection_by_parents(
     size, row_limits, col_limits, weights, props, maximise
 ):
-    """ Create a population, get its fitness and select potential parents
-    based on that fitness. Verify that parents are all valid individuals. """
+    """Create a population, get its fitness and select potential parents
+    based on that fitness. Verify that parents are all valid individuals."""
 
     best_prop, lucky_prop = props
     distributions = [Gamma, Normal, Poisson]

--- a/tests/test_shrink.py
+++ b/tests/test_shrink.py
@@ -16,9 +16,9 @@ from .util.trivials import trivial_fitness
 def test_shrink(
     size, row_limits, col_limits, weights, props, maximise, compact_ratio, itr
 ):
-    """ Test that the search space (the space of pdf parameter limits) of a
+    """Test that the search space (the space of pdf parameter limits) of a
     hypothetical GA is reduced and centred around the best individuals'
-    parameters at a particular iteration. """
+    parameters at a particular iteration."""
 
     best_prop, lucky_prop = props
     distributions = [Gamma, Normal, Poisson]


### PR DESCRIPTION
Removing the versions for the formatter libs so that the most up-to-date formatting is done, i.e. new PEPs, etc. This happens in the CI anyway.