### PR TITLE
Set sphinxcontrib-bibtex version to <2.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ numpydoc
 scikit-learn
 sphinx
 sphinx_rtd_theme
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex<2.0.0
 
 # Doctests and linting
 blackbook


### PR DESCRIPTION
Documentation builds have been failing with this error:

```zsh
$ make html
Running Sphinx v3.4.3
loading pickled environment... failed
failed: No module named 'sphinxcontrib.bibtex.cache'

Extension error:
You must configure the bibtex_bibfiles setting
make: *** [html] Error 2
```

A quick fix is to set the `sphinxcontrib-bibtex` version to `<2.0.0` (as per this issue: https://github.com/executablebooks/jupyter-book/issues/1137)